### PR TITLE
Add registration flow and subscription overview

### DIFF
--- a/simhub/admin/index.php
+++ b/simhub/admin/index.php
@@ -3,16 +3,69 @@ require_once __DIR__ . '/../src/Database.php';
 require_once __DIR__ . '/../src/Auth.php';
 Auth::start();
 if (!Auth::isAdmin()) { header('Location: /login.php'); exit; }
+$user = Auth::user();
 ?>
 <!DOCTYPE html>
-<html lang="it"><head>
-<meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Admin • MetaSim</title>
-<script src="https://cdn.tailwindcss.com"></script>
-</head><body class="bg-gray-100">
-<div class="max-w-5xl mx-auto p-6">
-  <h1 class="text-2xl font-bold mb-4">Pannello Admin</h1>
-  <p class="mb-6 text-sm text-gray-600">Gestione contenuti (visibile solo con ruolo admin).</p>
-  <a href="/" class="underline">← Torna al sito</a>
-</div>
-</body></html>
+<html lang="it">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>RaceVerse • Admin Control</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="/assets/css/style.css">
+</head>
+<body class="bg-[#0f1117] text-gray-100 min-h-screen">
+  <div class="max-w-6xl mx-auto px-6 py-10 space-y-8">
+    <header class="rounded-3xl p-8 bg-gradient-to-r from-amber-500/30 via-orange-500/10 to-emerald-500/10 border border-white/10 shadow-2xl">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+        <div>
+          <p class="text-xs uppercase tracking-[0.35em] text-amber-100/70 mb-2">RaceVerse Admin Suite</p>
+          <h1 class="text-3xl md:text-4xl font-black">Centro di controllo</h1>
+          <p class="text-sm text-amber-100/80 mt-2">Gestisci contenuti, utenti e asset del servizio. Ogni modifica viene sincronizzata in tempo reale con il front-end pubblico.</p>
+        </div>
+        <div class="rounded-2xl bg-black/40 border border-amber-300/40 px-5 py-4 text-right">
+          <div class="text-xs uppercase tracking-[0.3em] text-amber-200">Admin</div>
+          <div class="font-semibold text-lg"><?= htmlspecialchars($user['email']) ?></div>
+          <a href="/" class="text-sm text-amber-100/70 underline">← Torna al sito</a>
+        </div>
+      </div>
+    </header>
+
+    <section class="grid gap-6 lg:grid-cols-3">
+      <div class="rounded-3xl border border-white/15 bg-black/40 p-6">
+        <div class="text-xs uppercase tracking-[0.25em] text-white/60">Database cars</div>
+        <h2 class="text-xl font-semibold mt-3">Auto & categorie</h2>
+        <p class="text-sm text-white/70 mt-2">Aggiungi nuove vetture per Le Mans Ultimate, iRacing e ACC. Collega immagini e categorie per alimentare le raccomandazioni.</p>
+        <a href="#" class="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-2xl bg-white text-black text-sm font-semibold">Gestisci garage</a>
+      </div>
+      <div class="rounded-3xl border border-white/15 bg-black/40 p-6">
+        <div class="text-xs uppercase tracking-[0.25em] text-white/60">Hotlap intelligence</div>
+        <h2 class="text-xl font-semibold mt-3">Classifiche e tempi</h2>
+        <p class="text-sm text-white/70 mt-2">Aggiorna i record dei pro-player, definisci la vettura dominante per ogni pista e pubblica analisi meta.</p>
+        <a href="#" class="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-2xl bg-emerald-400 text-black text-sm font-semibold">Gestisci hotlap</a>
+      </div>
+      <div class="rounded-3xl border border-white/15 bg-black/40 p-6">
+        <div class="text-xs uppercase tracking-[0.25em] text-white/60">Premium setups</div>
+        <h2 class="text-xl font-semibold mt-3">Assetti</h2>
+        <p class="text-sm text-white/70 mt-2">Carica i file assetto aggiornati, separa configurazioni qualifica/gara e associa note tecniche.</p>
+        <a href="#" class="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-2xl bg-purple-400 text-black text-sm font-semibold">Gestisci assetti</a>
+      </div>
+    </section>
+
+    <section class="rounded-3xl border border-white/15 bg-black/50 p-8">
+      <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+        <div>
+          <h2 class="text-2xl font-bold">Gestione community</h2>
+          <p class="text-sm text-white/70 mt-2">Crea nuovi profili, assegna ruoli (Admin, RaceVerse Pro, RaceVerse Guest) e abilita manualmente i piani di abbonamento.</p>
+        </div>
+        <a href="#" class="inline-flex items-center gap-2 px-5 py-3 rounded-2xl bg-amber-300 text-black text-sm font-semibold">Gestisci utenti</a>
+      </div>
+      <div class="mt-6 grid gap-4 md:grid-cols-3 text-sm text-white/70">
+        <div class="p-4 rounded-2xl border border-white/10 bg-black/40">• Invita nuovi piloti o staff</div>
+        <div class="p-4 rounded-2xl border border-white/10 bg-black/40">• Upgrade/downgrade dei ruoli</div>
+        <div class="p-4 rounded-2xl border border-white/10 bg-black/40">• Attiva o sospendi abbonamenti</div>
+      </div>
+    </section>
+  </div>
+</body>
+</html>

--- a/simhub/admin/login.php
+++ b/simhub/admin/login.php
@@ -13,7 +13,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <html lang="it">
 <head>
 <meta charset="utf-8"><meta name="viewport" content="width=device-width, initial-scale=1">
-<title>Login Admin</title>
+<title>RaceVerse • Login Admin</title>
 <script src="https://cdn.tailwindcss.com"></script>
 <link rel="stylesheet" href="/assets/css/style.css">
 </head>
@@ -21,7 +21,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <form method="post" class="glass border border-white/10 p-8 rounded-2xl w-[380px] max-w-[92vw]">
     <div class="flex items-center gap-3 mb-6">
       <img src="/assets/images/logo.png" class="w-10 h-10" alt="logo">
-      <h1 class="text-xl font-bold">Admin • SimHub</h1>
+      <h1 class="text-xl font-bold">Admin • RaceVerse</h1>
     </div>
     <?php if ($error): ?>
       <div class="mb-4 p-3 rounded bg-red-500/15 border border-red-500/25 text-red-200 text-sm"><?= htmlspecialchars($error) ?></div>

--- a/simhub/public/abbonamenti.php
+++ b/simhub/public/abbonamenti.php
@@ -1,0 +1,119 @@
+<?php
+require_once __DIR__ . '/../src/Auth.php';
+Auth::start();
+$currentUser = Auth::user();
+include __DIR__ . '/../templates/header.php';
+?>
+<section class="space-y-12">
+  <div class="rounded-3xl p-10 bg-gradient-to-br from-emerald-500/20 via-sky-500/10 to-purple-500/10 border border-white/10 shadow-2xl">
+    <div class="grid gap-8 lg:grid-cols-[1.2fr_1fr] items-center">
+      <div class="space-y-4">
+        <p class="uppercase tracking-[0.35em] text-xs text-white/60">RaceVerse Membership</p>
+        <h1 class="text-4xl md:text-5xl font-black leading-tight">Sblocca l'intero garage con RaceVerse Pro.</h1>
+        <p class="text-white/80 text-lg">Hotlap sempre aggiornati e un servizio di setup premium pensato per Le Mans Ultimate, iRacing e ACC. Con il piano RaceVerse Pro ricevi accesso immediato agli assetti di ogni combinazione pista/auto curata dai nostri coach.</p>
+        <div class="flex flex-wrap gap-3 text-sm text-white/70">
+          <span class="px-4 py-2 rounded-full border border-white/20 bg-black/40">Hotlap Meta Advisor</span>
+          <span class="px-4 py-2 rounded-full border border-white/20 bg-black/40">Setup Pro telemetrati</span>
+          <span class="px-4 py-2 rounded-full border border-white/20 bg-black/40">Aggiornamenti mensili inclusi</span>
+        </div>
+      </div>
+      <div class="rounded-3xl bg-white text-black p-6 md:p-8 shadow-xl">
+        <p class="text-sm uppercase tracking-[0.25em] text-emerald-600 mb-3">RaceVerse Pro</p>
+        <div class="flex items-baseline gap-2">
+          <span class="text-5xl font-black">5€</span>
+          <span class="text-sm font-semibold">/ mese</span>
+        </div>
+        <p class="mt-4 text-sm text-gray-700">Download illimitati, supporto prioritario e roadmap condivisa con il team di ingegneri RaceVerse.</p>
+        <ul class="mt-6 space-y-3 text-sm text-gray-800">
+          <li class="flex items-start gap-3"><span class="mt-1 w-2 h-2 rounded-full bg-emerald-500"></span>Setup completi per qualifica e gara</li>
+          <li class="flex items-start gap-3"><span class="mt-1 w-2 h-2 rounded-full bg-emerald-500"></span>Accesso anticipato a nuove piste e categorie</li>
+          <li class="flex items-start gap-3"><span class="mt-1 w-2 h-2 rounded-full bg-emerald-500"></span>Report meta cross-game aggiornati ogni settimana</li>
+        </ul>
+        <a href="<?= $currentUser ? '/account.php' : '/login.php?tab=register' ?>" class="mt-6 inline-flex justify-center items-center w-full py-3 rounded-2xl bg-emerald-500 text-black font-semibold uppercase tracking-[0.2em]">Attiva RaceVerse Pro</a>
+        <p class="mt-4 text-xs text-gray-500 text-center">Cancella quando vuoi. Assetti futuri inclusi durante il periodo attivo.</p>
+      </div>
+    </div>
+  </div>
+
+  <div class="rounded-3xl border border-white/10 bg-black/40 p-8 md:p-10 space-y-8">
+    <div>
+      <h2 class="text-3xl font-bold">Confronto dei piani</h2>
+      <p class="text-white/70 mt-2">Scegli il livello di accesso più adatto: gratuito per consultare la meta, Pro per scaricare tutto, oppure acquista singolarmente un setup specifico.</p>
+    </div>
+    <div class="overflow-x-auto">
+      <table class="w-full text-sm text-left">
+        <thead class="text-white/60 uppercase tracking-[0.2em] text-xs">
+          <tr>
+            <th class="py-3 px-4"></th>
+            <th class="py-3 px-4">RaceVerse Guest</th>
+            <th class="py-3 px-4">RaceVerse Pro</th>
+            <th class="py-3 px-4">Setup singolo</th>
+          </tr>
+        </thead>
+        <tbody class="divide-y divide-white/10">
+          <tr>
+            <td class="py-4 px-4 text-white/70">Prezzo</td>
+            <td class="py-4 px-4">Gratis</td>
+            <td class="py-4 px-4">5€/mese</td>
+            <td class="py-4 px-4">1,99€ una tantum</td>
+          </tr>
+          <tr>
+            <td class="py-4 px-4 text-white/70">Hotlap migliori auto/pista</td>
+            <td class="py-4 px-4">✔</td>
+            <td class="py-4 px-4">✔</td>
+            <td class="py-4 px-4">✔</td>
+          </tr>
+          <tr>
+            <td class="py-4 px-4 text-white/70">Download assetti completi</td>
+            <td class="py-4 px-4">—</td>
+            <td class="py-4 px-4">✔ Illimitati</td>
+            <td class="py-4 px-4">✔ Solo per la combo acquistata</td>
+          </tr>
+          <tr>
+            <td class="py-4 px-4 text-white/70">Aggiornamenti automatici</td>
+            <td class="py-4 px-4">—</td>
+            <td class="py-4 px-4">✔ Compresi nel mese</td>
+            <td class="py-4 px-4">—</td>
+          </tr>
+          <tr>
+            <td class="py-4 px-4 text-white/70">Supporto tecnico prioritario</td>
+            <td class="py-4 px-4">—</td>
+            <td class="py-4 px-4">✔</td>
+            <td class="py-4 px-4">Supporto via email 72h</td>
+          </tr>
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <div class="grid gap-6 md:grid-cols-3">
+    <div class="rounded-3xl border border-white/10 bg-black/50 p-6 space-y-3">
+      <h3 class="text-xl font-semibold">Perché restare Guest</h3>
+      <p class="text-sm text-white/70">Perfetto se vuoi monitorare gratuitamente il meta delle auto e capire dove investire tempo in pista.</p>
+      <ul class="text-sm text-white/60 space-y-2">
+        <li>• Accesso immediato dopo la registrazione</li>
+        <li>• Hotlap dei pro per ogni pista</li>
+        <li>• Suggerimenti auto e categorie</li>
+      </ul>
+    </div>
+    <div class="rounded-3xl border border-emerald-400/40 bg-emerald-500/10 p-6 space-y-3">
+      <h3 class="text-xl font-semibold">Quando passare a Pro</h3>
+      <p class="text-sm text-emerald-50/80">Se vuoi copiare setup vincenti e ricevere aggiornamenti costanti per ogni gioco supportato.</p>
+      <ul class="text-sm text-emerald-100/80 space-y-2">
+        <li>• Assetti pronta gara e qualifica</li>
+        <li>• Telemetria e note di guida dei coach</li>
+        <li>• Voto prioritario sulle prossime release</li>
+      </ul>
+    </div>
+    <div class="rounded-3xl border border-white/10 bg-black/50 p-6 space-y-3">
+      <h3 class="text-xl font-semibold">Acquisto singolo</h3>
+      <p class="text-sm text-white/70">Hai bisogno di un solo assetto per un evento specifico? Paghi solo ciò che ti serve, senza abbonamento.</p>
+      <ul class="text-sm text-white/60 space-y-2">
+        <li>• File setup e guida rapida</li>
+        <li>• Aggiornamento garantito 30 giorni</li>
+        <li>• Possibilità di upgrade al Pro scalando il costo</li>
+      </ul>
+    </div>
+  </div>
+</section>
+<?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/simhub/public/account.php
+++ b/simhub/public/account.php
@@ -4,38 +4,179 @@ require_once __DIR__ . '/../src/Auth.php';
 Auth::start();
 $user = Auth::user();
 if (!$user) { header('Location: /login.php'); exit; }
+$roleLabel = Auth::roleLabel($user['role']);
+$hasSetupAccess = Auth::hasSetupAccess();
 include __DIR__ . '/../templates/header.php';
 ?>
-<section class="rounded-3xl p-6 md:p-8 bg-white/5 border border-white/10 mb-8">
-  <div class="flex items-center gap-3 mb-4">
-    <img src="/assets/images/logo.png" class="w-10 h-10" alt="logo">
-    <div>
-      <h1 class="text-2xl font-bold">Ciao, <?= htmlspecialchars($user['email']) ?></h1>
-      <p class="text-sm text-white/60">Ruolo: <strong><?= htmlspecialchars($user['role']) ?></strong> • Piano: <strong><?= htmlspecialchars($user['subscription_plan'] ?: 'Nessuno') ?></strong> <?= $user['subscription_active'] ? '✅' : '❌' ?></p>
+<section class="space-y-8">
+  <div class="rounded-3xl p-8 md:p-10 bg-gradient-to-br from-indigo-500/20 via-blue-500/10 to-emerald-500/10 border border-white/10">
+    <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-6">
+      <div class="flex items-start gap-4">
+        <img src="/assets/images/logo.png" class="w-14 h-14" alt="logo">
+        <div>
+          <p class="text-xs uppercase tracking-[0.35em] text-white/60 mb-2">RaceVerse Control Room</p>
+          <h1 class="text-3xl md:text-4xl font-black leading-tight">Benvenuto, <?= htmlspecialchars($user['email']) ?></h1>
+          <p class="text-white/70 mt-2">Ruolo corrente: <span class="font-semibold text-white"><?= htmlspecialchars($roleLabel) ?></span> • Piano: <span class="font-semibold text-white"><?= htmlspecialchars($user['subscription_plan'] ?: 'Nessuno') ?></span> <?= $user['subscription_active'] ? '✅' : '❌' ?></p>
+        </div>
+      </div>
+      <div class="flex flex-col gap-3 min-w-[220px]">
+        <a href="/logout.php" class="px-5 py-3 rounded-2xl bg-white/10 border border-white/20 text-sm text-center hover:bg-white/20">Esci dalla sessione</a>
+        <?php if (!$hasSetupAccess): ?>
+          <a href="#" class="px-5 py-3 rounded-2xl bg-emerald-400 text-black text-sm font-semibold text-center">Attiva RaceVerse Pro</a>
+        <?php else: ?>
+          <span class="px-5 py-3 rounded-2xl bg-emerald-500/20 border border-emerald-400/40 text-emerald-100 text-center text-sm">Accesso setup premium attivo</span>
+        <?php endif; ?>
+      </div>
     </div>
   </div>
 
-  <?php if (Auth::isAdmin()): ?>
-    <div class="mb-6 p-4 rounded-xl bg-amber-500/10 border border-amber-500/20">
-      <div class="font-semibold mb-1">Area Amministratore</div>
-      <p class="text-sm text-amber-200">Gestisci i contenuti dal <a href="/admin/index.php" class="underline">Pannello Admin</a>.</p>
+  <div class="rounded-3xl border border-white/10 bg-white/5 p-6 md:p-8">
+    <div class="flex flex-wrap items-center gap-3 border-b border-white/10 pb-4">
+      <button type="button" data-tab-button data-tab-target="overview" class="px-4 py-2 rounded-2xl text-sm font-semibold transition bg-white text-black shadow-lg">Dashboard</button>
+      <button type="button" data-tab-button data-tab-target="subscription" class="px-4 py-2 rounded-2xl text-sm font-semibold transition bg-white/10 border border-white/20 text-white/80 hover:bg-white/15">Subscription</button>
     </div>
-  <?php endif; ?>
 
-  <div class="grid grid-cols-1 md:grid-cols-2 gap-4">
-    <div class="p-5 rounded-xl bg-black/40 border border-white/10">
-      <h3 class="font-semibold mb-2">MetaVerse Pro</h3>
-      <p class="text-sm text-white/70 mb-3">Accesso al download degli assetti premium.</p>
-      <?php if (!Auth::isPro()): ?>
-        <a href="#" class="px-4 py-2 rounded-lg bg-white text-black inline-block">Attiva abbonamento</a>
-      <?php else: ?>
-        <span class="px-3 py-2 rounded-lg bg-emerald-600/30 border border-emerald-400/40 text-emerald-200 text-sm">Abbonamento attivo</span>
+    <div class="mt-6 space-y-6" data-tab-panel="overview">
+      <div class="grid gap-6 lg:grid-cols-3">
+        <div class="rounded-3xl border border-emerald-400/30 bg-emerald-500/10 p-6">
+          <div class="text-xs uppercase tracking-[0.25em] text-emerald-200">Insight meta</div>
+          <h2 class="text-xl font-semibold mt-3">Hotlap e consigli</h2>
+          <p class="text-sm text-emerald-100/80 mt-2">Accedi al database delle combinazioni pista/auto aggiornato ogni settimana dai nostri pro-driver.</p>
+          <ul class="mt-4 space-y-2 text-sm text-emerald-100/70">
+            <li>• Analisi cross-game (LMU, iRacing, ACC)</li>
+            <li>• Notifiche meta quando cambia l'auto dominante</li>
+            <li>• Preferiti personali per salvare i tuoi combo</li>
+          </ul>
+        </div>
+        <div class="rounded-3xl border border-white/10 bg-black/40 p-6">
+          <div class="text-xs uppercase tracking-[0.25em] text-white/60">Setup Lab</div>
+          <h2 class="text-xl font-semibold mt-3">Download assetti</h2>
+          <?php if ($hasSetupAccess): ?>
+            <p class="text-sm text-white/80 mt-2">Hai accesso a tutti i file assetto caricati dal team RaceVerse. Scarica la tua prossima configurazione vincente.</p>
+            <ul class="mt-4 space-y-2 text-sm text-white/70">
+              <li>• Telemetria MoTeC inclusa</li>
+              <li>• Setup per qualifica e gara</li>
+              <li>• Aggiornamenti gratuiti per l'intero mese</li>
+            </ul>
+            <a href="<?= asset('setups.php') ?>" class="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-2xl bg-emerald-400 text-black text-sm font-semibold">Vai ai setup</a>
+          <?php else: ?>
+            <p class="text-sm text-white/70 mt-2">Per scaricare i setup è necessario un piano RaceVerse Pro attivo. Scegli tra abbonamento mensile o singolo acquisto.</p>
+            <div class="mt-4 grid gap-3 text-sm">
+              <div class="p-3 rounded-2xl border border-white/15 bg-white/5">3,99€/mese • Accesso illimitato a tutti gli assetti</div>
+              <div class="p-3 rounded-2xl border border-white/15 bg-white/5">1,99€ • Acquisto singolo assetto</div>
+            </div>
+            <a href="#subscription" data-tab-jump="subscription" class="mt-5 inline-flex items-center gap-2 px-4 py-2 rounded-2xl bg-white text-black text-sm font-semibold">Diventa RaceVerse Pro</a>
+          <?php endif; ?>
+        </div>
+        <div class="rounded-3xl border border-amber-400/30 bg-amber-500/10 p-6">
+          <div class="text-xs uppercase tracking-[0.25em] text-amber-200">Roadmap</div>
+          <h2 class="text-xl font-semibold mt-3">Prossimi rilasci</h2>
+          <ul class="mt-4 space-y-3 text-sm text-amber-100/80">
+            <li>• Dashboard strategie gomme per gare endurance</li>
+            <li>• Coaching 1-to-1 con i nostri pro-driver</li>
+            <li>• Integrazione live con i rating iRacing</li>
+          </ul>
+          <p class="text-xs text-amber-100/70 mt-4">Suggerisci nuove feature direttamente dal canale Discord riservato ai membri.</p>
+        </div>
+      </div>
+
+      <?php if (Auth::isAdmin()): ?>
+        <section class="rounded-3xl border border-amber-400/40 bg-amber-500/10 p-8 space-y-6">
+          <div class="flex flex-col md:flex-row md:items-center md:justify-between gap-4">
+            <div>
+              <h2 class="text-2xl font-bold">Strumenti amministratore</h2>
+              <p class="text-sm text-amber-100/80 mt-1">Gestisci l'intero ecosistema RaceVerse: auto, hotlap, file assetto e ruoli utente.</p>
+            </div>
+            <a href="/admin/index.php" class="px-5 py-3 rounded-2xl bg-amber-300 text-black font-semibold text-sm">Apri pannello admin</a>
+          </div>
+          <div class="grid gap-4 md:grid-cols-2 xl:grid-cols-4 text-sm text-amber-100/80">
+            <div class="p-4 rounded-2xl border border-amber-300/40 bg-black/30">Nuove auto & categorie</div>
+            <div class="p-4 rounded-2xl border border-amber-300/40 bg-black/30">Aggiorna hotlap & classifiche</div>
+            <div class="p-4 rounded-2xl border border-amber-300/40 bg-black/30">Carica assetti premium</div>
+            <div class="p-4 rounded-2xl border border-amber-300/40 bg-black/30">Crea profili e assegna ruoli</div>
+          </div>
+        </section>
       <?php endif; ?>
     </div>
-    <div class="p-5 rounded-xl bg-black/40 border border-white/10">
-      <h3 class="font-semibold mb-2">Sessione</h3>
-      <a href="/logout.php" class="px-4 py-2 rounded-lg bg-white/10 border border-white/20 inline-block">Logout</a>
+
+    <div class="mt-6 space-y-6 hidden" data-tab-panel="subscription">
+      <div class="grid gap-6 lg:grid-cols-2">
+        <div class="rounded-3xl border border-white/15 bg-black/40 p-6">
+          <div class="text-xs uppercase tracking-[0.25em] text-white/60">Piano gratuito</div>
+          <h2 class="text-2xl font-bold mt-3">RaceVerse Guest</h2>
+          <p class="text-sm text-white/70 mt-2">Perfetto per iniziare subito: consulti gli hotlap pubblici, esplori la meta aggiornata e scopri quale vettura domina sulla pista scelta senza costi.</p>
+          <ul class="mt-4 space-y-2 text-sm text-white/60">
+            <li>• Accesso illimitato al database hotlap</li>
+            <li>• Consigli su auto & combinazioni pista</li>
+            <li>• Roadmap e aggiornamenti community</li>
+          </ul>
+          <div class="mt-6 px-4 py-3 rounded-2xl border border-white/15 bg-white/5 text-sm text-white/70">Incluso nel tuo profilo attuale.</div>
+        </div>
+        <div class="rounded-3xl border border-emerald-400/50 bg-emerald-500/15 p-6 relative overflow-hidden">
+          <span class="absolute top-4 right-4 px-3 py-1 rounded-full text-xs uppercase tracking-[0.25em] bg-white text-black">Pro</span>
+          <div class="text-xs uppercase tracking-[0.25em] text-emerald-100">Piano premium</div>
+          <h2 class="text-2xl font-bold mt-3">RaceVerse Pro</h2>
+          <p class="text-sm text-emerald-50/90 mt-2">La soluzione completa per replicare i tempi dei pro: scarichi tutti gli assetti ottimizzati per LMU, iRacing e ACC e ricevi aggiornamenti costanti.</p>
+          <div class="mt-5 text-4xl font-black text-emerald-100">3,99€<span class="text-base font-semibold">/mese</span></div>
+          <p class="text-xs text-emerald-100/80">Oppure acquista i singoli assetti a 1,99€.</p>
+          <ul class="mt-5 space-y-2 text-sm text-emerald-50/80">
+            <li>• Download illimitato di tutti i setup</li>
+            <li>• Accesso a telemetria & consigli personalizzati</li>
+            <li>• Aggiornamenti meta prioritari e Discord riservato</li>
+          </ul>
+          <?php if ($hasSetupAccess): ?>
+            <div class="mt-6 px-4 py-3 rounded-2xl border border-emerald-200/60 bg-emerald-400/20 text-sm text-emerald-900 font-semibold">Hai già un abbonamento attivo RaceVerse Pro.</div>
+          <?php else: ?>
+            <a href="#" class="mt-6 inline-flex items-center justify-center gap-2 px-5 py-3 rounded-2xl bg-white text-black text-sm font-semibold">Attiva RaceVerse Pro</a>
+          <?php endif; ?>
+        </div>
+      </div>
+      <div class="rounded-3xl border border-white/10 bg-black/30 p-6">
+        <h3 class="text-lg font-semibold">Cosa include l'abbonamento</h3>
+        <div class="mt-4 grid gap-4 md:grid-cols-3 text-sm text-white/70">
+          <div class="p-4 rounded-2xl border border-white/10 bg-white/5">Setup per ogni pista e condizione meteo</div>
+          <div class="p-4 rounded-2xl border border-white/10 bg-white/5">Analisi telemetria condivise dai RaceVerse coach</div>
+          <div class="p-4 rounded-2xl border border-white/10 bg-white/5">Supporto prioritario per richieste assetti</div>
+        </div>
+      </div>
     </div>
   </div>
 </section>
+<script>
+  const tabButtons = document.querySelectorAll('[data-tab-button]');
+  const tabPanels = document.querySelectorAll('[data-tab-panel]');
+  const jumpLinks = document.querySelectorAll('[data-tab-jump]');
+
+  function activateTab(target) {
+    tabButtons.forEach(btn => {
+      const isActive = btn.getAttribute('data-tab-target') === target;
+      btn.classList.toggle('bg-white', isActive);
+      btn.classList.toggle('text-black', isActive);
+      btn.classList.toggle('shadow-lg', isActive);
+      btn.classList.toggle('bg-white/10', !isActive);
+      btn.classList.toggle('border', !isActive);
+      btn.classList.toggle('border-white/20', !isActive);
+      btn.classList.toggle('text-white/80', !isActive);
+      btn.classList.toggle('hover:bg-white/15', !isActive);
+    });
+    tabPanels.forEach(panel => {
+      panel.classList.toggle('hidden', panel.getAttribute('data-tab-panel') !== target);
+    });
+  }
+
+  tabButtons.forEach(btn => {
+    btn.addEventListener('click', () => activateTab(btn.getAttribute('data-tab-target')));
+  });
+
+  jumpLinks.forEach(link => {
+    link.addEventListener('click', event => {
+      event.preventDefault();
+      activateTab(link.getAttribute('data-tab-jump'));
+      const subscriptionPanel = document.querySelector('[data-tab-panel="subscription"]');
+      subscriptionPanel?.scrollIntoView({ behavior: 'smooth', block: 'start' });
+    });
+  });
+
+  activateTab('overview');
+</script>
 <?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/simhub/public/api/categories.php
+++ b/simhub/public/api/categories.php
@@ -1,0 +1,14 @@
+<?php
+header('Content-Type: application/json; charset=utf-8');
+require_once __DIR__ . '/../../src/Database.php';
+$pdo = Database::pdo();
+$game = isset($_GET['game']) ? (int)$_GET['game'] : 0;
+if (!$game) { echo json_encode([]); exit; }
+$sql = "SELECT DISTINCT c.id, c.name
+        FROM categories c
+        JOIN cars car ON car.category_id = c.id
+        WHERE car.game_id = ?
+        ORDER BY c.name";
+$st = $pdo->prepare($sql);
+$st->execute([$game]);
+echo json_encode($st->fetchAll() ?: []);

--- a/simhub/public/login.php
+++ b/simhub/public/login.php
@@ -2,32 +2,177 @@
 require_once __DIR__ . '/../src/Database.php';
 require_once __DIR__ . '/../src/Auth.php';
 Auth::start();
-$error=null;
-if ($_SERVER['REQUEST_METHOD']==='POST') {
-  if (Auth::login($_POST['email']??'', $_POST['password']??'')) {
-    header('Location: /account.php'); exit;
-  } else { $error='Credenziali non valide'; }
+$user = Auth::user();
+if ($user) { header('Location: /account.php'); exit; }
+$loginError = null;
+$registerError = null;
+$registerEmail = '';
+$activeTab = $_GET['tab'] ?? 'login';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+  $formType = $_POST['form_type'] ?? 'login';
+
+  if ($formType === 'register') {
+    $activeTab = 'register';
+    $registerEmail = trim($_POST['register_email'] ?? '');
+    $password = $_POST['register_password'] ?? '';
+    $confirm = $_POST['register_password_confirmation'] ?? '';
+
+    if ($password !== $confirm) {
+      $registerError = 'Le password non coincidono.';
+    } else {
+      [$success, $message] = Auth::register($registerEmail, $password);
+      if ($success) {
+        header('Location: /account.php');
+        exit;
+      }
+      $registerError = $message;
+    }
+  } else {
+    $activeTab = 'login';
+    if (Auth::login($_POST['email'] ?? '', $_POST['password'] ?? '')) {
+      header('Location: /account.php');
+      exit;
+    }
+    $loginError = 'Credenziali non valide';
+  }
 }
 include __DIR__ . '/../templates/header.php';
 ?>
-<section class="max-w-md mx-auto rounded-2xl p-6 md:p-8 bg-white/5 border border-white/10">
-  <div class="flex items-center gap-3 mb-6">
-    <img src="/assets/images/logo.png" class="w-10 h-10" alt="logo">
-    <h1 class="text-xl font-bold">Accedi</h1>
+<section class="grid grid-cols-1 xl:grid-cols-[1.3fr_1fr] gap-10 items-start">
+  <div class="space-y-8">
+    <div class="p-6 md:p-10 rounded-3xl bg-gradient-to-br from-emerald-500/20 via-sky-500/15 to-purple-600/10 border border-white/10 shadow-2xl">
+      <p class="uppercase tracking-[0.35em] text-xs text-white/60 mb-4">RaceVerse Performance Garage</p>
+      <h1 class="text-4xl md:text-5xl font-black leading-tight mb-4">Un solo hub per scegliere l'auto perfetta e scaricare i setup dei pro.</h1>
+      <p class="text-white/80 text-lg max-w-3xl">Analizziamo gli hotlap di Le Mans Ultimate, iRacing e ACC per mostrarti quale vettura domina ogni pista, in ogni categoria. Con il piano <strong>RaceVerse Pro</strong> sblocchi i setup ufficiali dei nostri coach per replicare la performance in pista.</p>
+      <ul class="grid sm:grid-cols-2 gap-4 mt-8 text-sm text-white/80">
+        <li class="flex items-start gap-3 p-4 rounded-2xl bg-black/40 border border-white/10"><span class="mt-1 w-2 h-2 rounded-full bg-emerald-400"></span><div><strong>Database hotlap live</strong><br>Ogni combinazione pista/auto aggiornata dai pro.</div></li>
+        <li class="flex items-start gap-3 p-4 rounded-2xl bg-black/40 border border-white/10"><span class="mt-1 w-2 h-2 rounded-full bg-sky-400"></span><div><strong>Meta Advisor</strong><br>Consigli automatici sull'auto più competitiva.</div></li>
+        <li class="flex items-start gap-3 p-4 rounded-2xl bg-black/40 border border-white/10"><span class="mt-1 w-2 h-2 rounded-full bg-amber-400"></span><div><strong>Setup esclusivi</strong><br>Scarica assetti pronti all'uso per ogni gioco supportato.</div></li>
+        <li class="flex items-start gap-3 p-4 rounded-2xl bg-black/40 border border-white/10"><span class="mt-1 w-2 h-2 rounded-full bg-purple-400"></span><div><strong>Roadmap condivisa</strong><br>Vota le prossime piste da analizzare e i pacchetti setup.</div></li>
+      </ul>
+    </div>
+
+    <div class="bg-white/3 border border-white/10 rounded-3xl p-6 md:p-8">
+      <h2 class="text-2xl font-bold mb-1">Ruoli e privilegi</h2>
+      <p class="text-sm text-white/70 mb-6">Ogni gruppo all'interno di RaceVerse ha accessi differenti. Scopri cosa sblocchi quando effettui il login.</p>
+      <div class="grid gap-4 md:grid-cols-3">
+        <div class="rounded-2xl border border-amber-400/40 bg-amber-500/10 p-5">
+          <div class="text-xs uppercase tracking-[0.2em] text-amber-200">Admin</div>
+          <div class="text-lg font-semibold mt-2">Gestione totale</div>
+          <ul class="mt-3 space-y-2 text-sm text-amber-100/80">
+            <li>• Inserisci e modifica auto</li>
+            <li>• Aggiorna hotlap ufficiali</li>
+            <li>• Carica i file assetto premium</li>
+            <li>• Assegna ruoli e abbonamenti</li>
+          </ul>
+        </div>
+        <div class="rounded-2xl border border-emerald-400/40 bg-emerald-500/10 p-5">
+          <div class="text-xs uppercase tracking-[0.2em] text-emerald-200">RaceVerse Pro</div>
+          <div class="text-lg font-semibold mt-2">Setup illimitati</div>
+          <ul class="mt-3 space-y-2 text-sm text-emerald-100/80">
+            <li>• Scarica ogni assetto disponibile</li>
+            <li>• Accesso anticipato ai meta report</li>
+            <li>• Telemetria e consigli personalizzati</li>
+          </ul>
+        </div>
+        <div class="rounded-2xl border border-white/10 bg-black/50 p-5">
+          <div class="text-xs uppercase tracking-[0.2em] text-white/60">RaceVerse Guest</div>
+          <div class="text-lg font-semibold mt-2">Accesso gratuito</div>
+          <ul class="mt-3 space-y-2 text-sm text-white/70">
+            <li>• Consulta i migliori hotlap</li>
+            <li>• Scopri l'auto più veloce per pista</li>
+            <li>• Upgrade rapido per i setup premium</li>
+          </ul>
+        </div>
+      </div>
+    </div>
   </div>
-  <?php if ($error): ?>
-    <div class="mb-4 p-3 rounded bg-red-500/15 border border-red-500/25 text-red-200 text-sm"><?= htmlspecialchars($error) ?></div>
-  <?php endif; ?>
-  <form method="post" class="space-y-3">
-    <div>
-      <label class="block text-sm mb-1">Email</label>
-      <input type="email" name="email" class="w-full p-3 rounded-xl bg-white/5 border border-white/20" required>
+
+  <div class="sticky top-28">
+    <div class="rounded-3xl p-8 bg-white/10 border border-white/20 shadow-xl backdrop-blur">
+      <div class="flex items-center gap-3 mb-6">
+        <img src="/assets/images/logo.png" class="w-12 h-12" alt="logo">
+        <div>
+          <p class="text-xs uppercase tracking-[0.3em] text-white/60">RaceVerse Access</p>
+          <h2 class="text-2xl font-bold">Accedi o crea un profilo</h2>
+        </div>
+      </div>
+
+      <div class="flex mb-6 rounded-2xl bg-black/30 border border-white/10 p-1" data-auth-tabs>
+        <button type="button" data-auth-tab="login" class="flex-1 px-4 py-2 rounded-2xl text-sm font-semibold <?= $activeTab === 'register' ? 'text-white/70' : 'bg-white text-black shadow-lg' ?>">Login</button>
+        <button type="button" data-auth-tab="register" class="flex-1 px-4 py-2 rounded-2xl text-sm font-semibold <?= $activeTab === 'register' ? 'bg-white text-black shadow-lg' : 'text-white/70' ?>">Registrati</button>
+      </div>
+
+      <div data-auth-panel="login" class="space-y-4 <?= $activeTab === 'register' ? 'hidden' : '' ?>">
+        <?php if ($loginError): ?>
+          <div class="p-3 rounded-xl bg-red-500/15 border border-red-500/25 text-red-200 text-sm"><?= htmlspecialchars($loginError) ?></div>
+        <?php endif; ?>
+        <form method="post" class="space-y-4">
+          <input type="hidden" name="form_type" value="login">
+          <div>
+            <label class="block text-sm mb-1 text-white/70">Email</label>
+            <input type="email" name="email" class="w-full p-3 rounded-2xl bg-black/40 border border-white/15 focus:border-emerald-400/60 focus:outline-none" placeholder="nome@raceverse.gg" required>
+          </div>
+          <div>
+            <label class="block text-sm mb-1 text-white/70">Password</label>
+            <input type="password" name="password" class="w-full p-3 rounded-2xl bg-black/40 border border-white/15 focus:border-emerald-400/60 focus:outline-none" placeholder="••••••••" required>
+          </div>
+          <button class="w-full py-3 rounded-2xl bg-emerald-400 text-black font-semibold text-sm uppercase tracking-[0.2em]">Entra in RaceVerse</button>
+        </form>
+        <div class="text-xs text-white/60 leading-relaxed">
+          Accedendo con un profilo <strong>RaceVerse Pro</strong> avrai download illimitati degli assetti.
+        </div>
+      </div>
+
+      <div data-auth-panel="register" class="space-y-4 <?= $activeTab === 'register' ? '' : 'hidden' ?>">
+        <?php if ($registerError): ?>
+          <div class="p-3 rounded-xl bg-red-500/15 border border-red-500/25 text-red-200 text-sm"><?= htmlspecialchars($registerError) ?></div>
+        <?php endif; ?>
+        <form method="post" class="space-y-4">
+          <input type="hidden" name="form_type" value="register">
+          <div>
+            <label class="block text-sm mb-1 text-white/70">Email</label>
+            <input type="email" name="register_email" value="<?= htmlspecialchars($registerEmail) ?>" class="w-full p-3 rounded-2xl bg-black/40 border border-white/15 focus:border-emerald-400/60 focus:outline-none" placeholder="nome@raceverse.gg" required>
+          </div>
+          <div class="grid gap-4 md:grid-cols-2">
+            <div>
+              <label class="block text-sm mb-1 text-white/70">Password</label>
+              <input type="password" name="register_password" class="w-full p-3 rounded-2xl bg-black/40 border border-white/15 focus:border-emerald-400/60 focus:outline-none" placeholder="Minimo 8 caratteri" required>
+            </div>
+            <div>
+              <label class="block text-sm mb-1 text-white/70">Conferma password</label>
+              <input type="password" name="register_password_confirmation" class="w-full p-3 rounded-2xl bg-black/40 border border-white/15 focus:border-emerald-400/60 focus:outline-none" placeholder="Ripeti la password" required>
+            </div>
+          </div>
+          <div class="text-xs text-white/60 bg-black/30 border border-white/10 rounded-2xl p-4">
+            La registrazione crea un profilo <strong>RaceVerse Guest</strong> gratuito. Potrai passare a <a class="text-emerald-300 underline" href="/abbonamenti.php">RaceVerse Pro</a> per sbloccare gli assetti premium.
+          </div>
+          <button class="w-full py-3 rounded-2xl bg-emerald-400 text-black font-semibold text-sm uppercase tracking-[0.2em]">Crea il tuo account gratuito</button>
+        </form>
+      </div>
+
+      <div class="mt-6 text-sm text-white/60 space-y-2">
+        <p>Abbonamento completo a <strong>5,00€/mese</strong> per scaricare tutti gli assetti. Vuoi un singolo setup? Disponibile a <strong>1,99€</strong>.</p>
+        <p class="text-white/50">L'accesso agli assetti è riservato a chi possiede un piano attivo RaceVerse Pro.</p>
+      </div>
     </div>
-    <div>
-      <label class="block text-sm mb-1">Password</label>
-      <input type="password" name="password" class="w-full p-3 rounded-xl bg-white/5 border border-white/20" required>
-    </div>
-    <button class="w-full py-3 rounded-xl bg-white text-black font-semibold">Entra</button>
-  </form>
+  </div>
 </section>
+<script>
+document.querySelectorAll('[data-auth-tab]').forEach((button) => {
+  button.addEventListener('click', () => {
+    const target = button.getAttribute('data-auth-tab');
+    document.querySelectorAll('[data-auth-panel]').forEach((panel) => {
+      panel.classList.toggle('hidden', panel.getAttribute('data-auth-panel') !== target);
+    });
+    document.querySelectorAll('[data-auth-tab]').forEach((btn) => {
+      btn.classList.remove('bg-white', 'text-black', 'shadow-lg');
+      btn.classList.add('text-white/70');
+    });
+    button.classList.add('bg-white', 'text-black', 'shadow-lg');
+    button.classList.remove('text-white/70');
+  });
+});
+</script>
 <?php include __DIR__ . '/../templates/footer.php'; ?>

--- a/simhub/schema.sql
+++ b/simhub/schema.sql
@@ -8,8 +8,8 @@ CREATE TABLE IF NOT EXISTS users (
   id INT AUTO_INCREMENT PRIMARY KEY,
   email VARCHAR(190) NOT NULL UNIQUE,
   password_hash VARCHAR(255) NOT NULL,
-  role ENUM('admin','user') NOT NULL DEFAULT 'user',
-  subscription_plan VARCHAR(64) DEFAULT NULL, -- 'MetaVerse Pro'
+  role ENUM('admin','pro','guest') NOT NULL DEFAULT 'guest',
+  subscription_plan VARCHAR(64) DEFAULT NULL, -- 'RaceVerse Pro'
   subscription_active TINYINT(1) NOT NULL DEFAULT 0,
   created_at TIMESTAMP DEFAULT CURRENT_TIMESTAMP
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
@@ -65,5 +65,15 @@ ON DUPLICATE KEY UPDATE name=VALUES(name);
 
 -- Admin demo: admin@example.com / admin123
 INSERT INTO users (email,password_hash,role,subscription_plan,subscription_active)
-VALUES ('admin@example.com', '$2y$10$wH5iC7R0iHq1w1e9VvbDWO9sV.8Xv1VdOZC2kQd7t0OQv3RrQqU9K', 'admin', 'MetaVerse Pro', 1)
-ON DUPLICATE KEY UPDATE role='admin';
+VALUES ('admin@example.com', '$2y$10$wH5iC7R0iHq1w1e9VvbDWO9sV.8Xv1VdOZC2kQd7t0OQv3RrQqU9K', 'admin', 'RaceVerse Pro', 1)
+ON DUPLICATE KEY UPDATE role='admin', subscription_plan='RaceVerse Pro', subscription_active=1;
+
+-- Demo RaceVerse Pro member
+INSERT INTO users (email,password_hash,role,subscription_plan,subscription_active)
+VALUES ('pro@example.com', '$2y$10$wH5iC7R0iHq1w1e9VvbDWO9sV.8Xv1VdOZC2kQd7t0OQv3RrQqU9K', 'pro', 'RaceVerse Pro', 1)
+ON DUPLICATE KEY UPDATE role='pro', subscription_plan='RaceVerse Pro', subscription_active=1;
+
+-- Demo guest user
+INSERT INTO users (email,password_hash,role)
+VALUES ('guest@example.com', '$2y$10$wH5iC7R0iHq1w1e9VvbDWO9sV.8Xv1VdOZC2kQd7t0OQv3RrQqU9K', 'guest')
+ON DUPLICATE KEY UPDATE role='guest';

--- a/simhub/src/Auth.php
+++ b/simhub/src/Auth.php
@@ -1,28 +1,118 @@
 <?php
 class Auth {
-  public static function start(): void { if (session_status()===PHP_SESSION_NONE) session_start(); }
+  public const ROLE_ADMIN = 'admin';
+  public const ROLE_PRO   = 'pro';
+  public const ROLE_GUEST = 'guest';
+
+  public static function start(): void {
+    if (session_status() === PHP_SESSION_NONE) {
+      session_start();
+    }
+  }
+
+  public static function register(string $email, string $password): array {
+    self::start();
+    $email = strtolower(trim($email));
+
+    if (!filter_var($email, FILTER_VALIDATE_EMAIL)) {
+      return [false, 'Inserisci un indirizzo email valido.'];
+    }
+
+    if (strlen($password) < 8) {
+      return [false, 'La password deve contenere almeno 8 caratteri.'];
+    }
+
+    $pdo = Database::pdo();
+
+    try {
+      $stmt = $pdo->prepare(
+        'INSERT INTO users (email, password_hash, role, subscription_plan, subscription_active) VALUES (?, ?, ?, NULL, 0)'
+      );
+      $stmt->execute([
+        $email,
+        password_hash($password, PASSWORD_DEFAULT),
+        self::ROLE_GUEST,
+      ]);
+    } catch (PDOException $e) {
+      if ((int) $e->getCode() === 23000) {
+        return [false, 'Esiste già un account con questa email.'];
+      }
+      throw $e;
+    }
+
+    self::login($email, $password);
+
+    return [true, null];
+  }
+
   public static function login(string $email, string $password): bool {
     self::start();
     $pdo = Database::pdo();
-    $st = $pdo->prepare("SELECT id,email,password_hash,role,subscription_plan,subscription_active FROM users WHERE email=? LIMIT 1");
+    $st = $pdo->prepare(
+      "SELECT id,email,password_hash,role,subscription_plan,subscription_active FROM users WHERE email=? LIMIT 1"
+    );
     $st->execute([$email]);
     $u = $st->fetch();
     if ($u && password_verify($password, $u['password_hash'])) {
       $_SESSION['user'] = [
-        'id'=>$u['id'],
-        'email'=>$u['email'],
-        'role'=>$u['role'],
-        'subscription_plan'=>$u['subscription_plan'],
-        'subscription_active'=>(bool)$u['subscription_active'],
+        'id' => $u['id'],
+        'email' => $u['email'],
+        'role' => $u['role'],
+        'subscription_plan' => $u['subscription_plan'],
+        'subscription_active' => (bool) $u['subscription_active'],
       ];
       return true;
     }
     return false;
   }
-  public static function user(): ?array { self::start(); return $_SESSION['user'] ?? null; }
-  public static function logout(): void { self::start(); $_SESSION=[]; session_destroy(); }
-  public static function isAdmin(): bool { $u=self::user(); return $u && $u['role']==='admin'; }
+
+  public static function user(): ?array {
+    self::start();
+    return $_SESSION['user'] ?? null;
+  }
+
+  public static function logout(): void {
+    self::start();
+    $_SESSION = [];
+    session_destroy();
+  }
+
+  public static function isAdmin(): bool {
+    $u = self::user();
+    return $u && $u['role'] === self::ROLE_ADMIN;
+  }
+
   public static function isPro(): bool {
-    $u=self::user(); return $u && $u['subscription_plan']==='MetaVerse Pro' && $u['subscription_active'];
+    $u = self::user();
+    if (!$u) {
+      return false;
+    }
+    if ($u['role'] === self::ROLE_ADMIN) {
+      return true;
+    }
+    if ($u['role'] !== self::ROLE_PRO) {
+      return false;
+    }
+    $plan = $u['subscription_plan'];
+    return in_array($plan, ['RaceVerse Pro', 'MetaVerse Pro'], true)
+      && $u['subscription_active'];
+  }
+
+  public static function isGuest(): bool {
+    $u = self::user();
+    return $u && $u['role'] === self::ROLE_GUEST;
+  }
+
+  public static function hasSetupAccess(): bool {
+    return self::isPro();
+  }
+
+  public static function roleLabel(?string $role): string {
+    return match ($role) {
+      self::ROLE_ADMIN => 'Admin',
+      self::ROLE_PRO => 'RaceVerse Pro',
+      self::ROLE_GUEST, 'user' => 'RaceVerse Guest',
+      default => $role ?? 'Sconosciuto',
+    };
   }
 }

--- a/simhub/templates/footer.php
+++ b/simhub/templates/footer.php
@@ -6,9 +6,9 @@ require_once __DIR__ . '/../src/helpers.php';
   <div class="max-w-7xl mx-auto px-4 md:px-6 py-8 flex items-center justify-between">
     <div class="flex items-center gap-3">
       <img src="<?= asset('assets/images/logo.png') ?>" class="w-8 h-8" alt="logo">
-      <span class="text-sm text-gray-300">© 2025 MetaSim</span>
+      <span class="text-sm text-gray-300">© 2025 RaceVerse</span>
     </div>
-    <div class="text-xs text-gray-400">MetaVerse Pro • Accesso assetti</div>
+    <div class="text-xs text-gray-400">RaceVerse Pro • Accesso completo agli assetti premium</div>
   </div>
 </footer>
 </body>

--- a/simhub/templates/header.php
+++ b/simhub/templates/header.php
@@ -1,11 +1,15 @@
 <?php
 require_once __DIR__ . '/../src/helpers.php';
+require_once __DIR__ . '/../src/Auth.php';
+
+Auth::start();
+$currentUser = Auth::user();
 ?>
 <!DOCTYPE html>
 <html lang="it">
 <head>
   <meta charset="UTF-8">
-  <title>MetaSim</title>
+  <title>RaceVerse Hub</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" href="<?= asset('assets/images/logo.png') ?>">
   <script src="https://cdn.tailwindcss.com"></script>
@@ -16,13 +20,23 @@ require_once __DIR__ . '/../src/helpers.php';
   <div class="max-w-7xl mx-auto px-4 py-3 flex items-center justify-between">
     <a href="<?= asset('index.php') ?>" class="flex items-center gap-3">
       <img src="<?= asset('assets/images/logo.png') ?>" class="w-8 h-8" alt="logo">
-      <span class="text-xl font-extrabold">MetaSim</span>
+      <span class="text-xl font-extrabold">RaceVerse</span>
     </a>
     <nav class="flex items-center gap-2 text-sm">
       <a href="<?= asset('index.php') ?>" class="px-3 py-2 hover:underline decoration-2">Home</a>
       <a href="<?= asset('hotlaps.php') ?>" class="px-3 py-2 hover:underline decoration-2">Hotlaps</a>
       <a href="<?= asset('setups.php') ?>" class="px-3 py-2 hover:underline decoration-2">Setups</a>
-      <a href="<?= asset('login.php') ?>" class="ml-2 px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 border border-white/20">Login</a>
+      <a href="<?= asset('abbonamenti.php') ?>" class="px-3 py-2 hover:underline decoration-2">Abbonamenti</a>
+      <?php if ($currentUser): ?>
+        <?php if (Auth::isAdmin()): ?>
+          <a href="<?= asset('admin/index.php') ?>" class="px-3 py-2 rounded-lg bg-amber-500/20 border border-amber-400/30 text-amber-200">Admin</a>
+        <?php endif; ?>
+        <a href="<?= asset('account.php') ?>" class="ml-2 px-4 py-2 rounded-lg bg-white text-black font-semibold flex items-center gap-2">
+          <span><?= htmlspecialchars(Auth::roleLabel($currentUser['role'])) ?></span>
+        </a>
+      <?php else: ?>
+        <a href="<?= asset('login.php') ?>" class="ml-2 px-4 py-2 rounded-lg bg-white/10 hover:bg-white/20 border border-white/20">Login</a>
+      <?php endif; ?>
     </nav>
   </div>
 </header>


### PR DESCRIPTION
## Summary
- add a registration tab to the login experience that stores new members as RaceVerse Guests and handles validation feedback
- extend the Auth service with a helper to create guest accounts before authenticating them
- introduce a dedicated Abbonamenti page and link it from the global navigation to showcase plan comparisons

## Testing
- php -l simhub/src/Auth.php
- php -l simhub/public/login.php
- php -l simhub/public/abbonamenti.php
- php -l simhub/templates/header.php

------
https://chatgpt.com/codex/tasks/task_e_68dceb75e65c832590bf3a47601872fd