### PR TITLE
Add MetaVerse Pro gated hotlap downloads

### DIFF
--- a/simhub/public/download.php
+++ b/simhub/public/download.php
@@ -1,0 +1,76 @@
+<?php
+require_once __DIR__ . '/../src/Database.php';
+require_once __DIR__ . '/../src/Auth.php';
+
+Auth::start();
+
+if (!Auth::isPro()) {
+    http_response_code(403);
+    header('Content-Type: text/html; charset=utf-8');
+    echo '<!DOCTYPE html><html lang="it"><head><meta charset="utf-8"><title>MetaVerse Pro richiesto</title>';
+    echo '<style>body{font-family:system-ui;background:#0f1117;color:#f8fafc;display:flex;align-items:center;justify-content:center;height:100vh;margin:0;}';
+    echo '.card{background:rgba(15,17,23,.85);border:1px solid rgba(255,255,255,.1);padding:2.5rem;border-radius:1.5rem;max-width:420px;text-align:center;}';
+    echo '.card a{color:#38bdf8;text-decoration:none;font-weight:600;}</style></head><body>';
+    echo '<div class="card"><h1 style="font-size:1.5rem;margin-bottom:0.75rem;">MetaVerse Pro richiesto</h1>';
+    echo '<p style="margin-bottom:1.25rem;line-height:1.6;">Il download degli assetti è riservato agli abbonati MetaVerse Pro.</p>';
+    echo '<a href="/account.php">Vai al tuo account</a></div></body></html>';
+    exit;
+}
+
+$hotlapId = isset($_GET['hotlap']) ? (int)$_GET['hotlap'] : 0;
+if ($hotlapId <= 0) {
+    http_response_code(400);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Hotlap non valida.";
+    exit;
+}
+
+$pdo = Database::pdo();
+$sql = "SELECT h.id, h.driver, h.lap_time_ms, h.recorded_at, c.name AS car_name, t.name AS track_name
+        FROM hotlaps h
+        JOIN cars c ON c.id = h.car_id
+        JOIN tracks t ON t.id = h.track_id
+        WHERE h.id = ?
+        LIMIT 1";
+$st = $pdo->prepare($sql);
+$st->execute([$hotlapId]);
+$row = $st->fetch();
+
+if (!$row) {
+    http_response_code(404);
+    header('Content-Type: text/plain; charset=utf-8');
+    echo "Hotlap non trovata.";
+    exit;
+}
+
+$slugify = static function (string $value): string {
+    $value = strtolower($value);
+    $value = preg_replace('/[^a-z0-9]+/i', '-', $value) ?? '';
+    $value = trim($value, '-');
+    return $value !== '' ? $value : 'setup';
+};
+
+$filenameParts = [
+    'setup',
+    $slugify($row['track_name']),
+    $slugify($row['car_name']),
+    'hotlap-' . $row['id'],
+];
+$filename = implode('-', array_filter($filenameParts)) . '.txt';
+
+$contentLines = [
+    'MetaVerse Pro – Assetto placeholder',
+    '----------------------------------',
+    'Pista: ' . $row['track_name'],
+    'Auto: ' . $row['car_name'],
+    'Pilota: ' . ($row['driver'] ?: 'N/D'),
+    'Tempo: ' . $row['lap_time_ms'] . ' ms',
+    'Registrato il: ' . ($row['recorded_at'] ?: 'N/D'),
+    '',
+    'Sostituisci questo file con il setup reale.',
+];
+
+header('Content-Type: text/plain; charset=utf-8');
+header('Content-Disposition: attachment; filename="' . $filename . '"');
+header('X-MetaSim-Hotlap-Id: ' . $row['id']);
+echo implode(PHP_EOL, $contentLines);

--- a/simhub/public/index.php
+++ b/simhub/public/index.php
@@ -1,5 +1,7 @@
 <?php
 require_once __DIR__ . '/../src/Database.php';
+require_once __DIR__ . '/../src/Auth.php';
+Auth::start();
 $pdo = Database::pdo();
 $games = $pdo->query("SELECT id,name FROM games ORDER BY name")->fetchAll();
 $categories = $pdo->query("SELECT id,name FROM categories ORDER BY name")->fetchAll();
@@ -8,6 +10,7 @@ $tracks = [];
 $st=$pdo->prepare("SELECT id,name FROM tracks WHERE game_id=? ORDER BY name");
 $st->execute([$defaultGame]);
 $tracks=$st->fetchAll();
+$canDownload = Auth::isPro();
 
 include __DIR__ . '/../templates/header.php';
 ?>
@@ -61,6 +64,7 @@ const catEl  = document.getElementById('sel-category');
 const trackEl= document.getElementById('sel-track');
 const results= document.getElementById('results');
 const btn    = document.getElementById('btn-search');
+const canDownload = <?= json_encode($canDownload) ?>;
 
 function fmt(ms){
   const m = Math.floor(ms/60000);
@@ -69,21 +73,28 @@ function fmt(ms){
   return m+":"+String(s).padStart(2,'0')+"."+String(mm).padStart(3,'0');
 }
 function card(item, idx){
+  const downloadCta = canDownload
+    ? `<a href="download.php?hotlap=${item.id}" class="px-4 py-2 rounded-lg bg-emerald-500/90 hover:bg-emerald-400 text-black font-semibold border border-emerald-300/60 transition">Download</a>`
+    : `<span class="px-4 py-2 rounded-lg bg-white/5 border border-white/10 text-white/40 cursor-not-allowed" title="Disponibile con MetaVerse Pro">Download</span>`;
   return `
-    <div class="p-4 rounded-xl bg-black/40 border border-white/10 flex items-center gap-4">
+    <div class="p-4 rounded-xl bg-black/40 border border-white/10 flex flex-wrap md:flex-nowrap items-center gap-4">
       <div class="w-20 h-12 bg-white/5 border border-white/10 rounded overflow-hidden flex items-center justify-center">
         ${item.car_image ? `<img src="${item.car_image}" class="w-full h-full object-cover">` : `<span class="text-xs text-white/50">no img</span>`}
       </div>
-      <div class="flex-1">
+      <div class="flex-1 min-w-[180px]">
         <div class="text-xs text-white/60">#${idx+1}</div>
         <div class="text-lg font-semibold">${item.car_name}</div>
         <div class="text-sm text-white/80">Best: <strong>${fmt(item.lap_time_ms)}</strong> • Driver: ${item.driver || '—'} • ${item.recorded_at?.slice(0,10) || ''}</div>
+      </div>
+      <div class="shrink-0 flex flex-col items-end gap-1 text-xs text-white/50">
+        ${downloadCta}
+        ${canDownload ? '' : '<span>MetaVerse Pro richiesto</span>'}
       </div>
     </div>`;
 }
 async function search(){
   results.innerHTML = `<div class="p-4 rounded-xl bg-black/30 border border-white/10">Caricamento…</div>`;
-  const url = `/api/hotlaps.php?game=${encodeURIComponent(gameEl.value)}&category=${encodeURIComponent(catEl.value)}&track=${encodeURIComponent(trackEl.value)}`;
+  const url = `api/hotlaps.php?game=${encodeURIComponent(gameEl.value)}&category=${encodeURIComponent(catEl.value)}&track=${encodeURIComponent(trackEl.value)}`;
   const res = await fetch(url);
   if (!res.ok){ results.innerHTML = `<div class="p-4 rounded-xl bg-red-600/20 border border-red-500/30 text-red-100">Errore nel caricamento</div>`; return; }
   const data = await res.json();
@@ -95,7 +106,7 @@ btn.addEventListener('click', search);
 
 // Cambia la lista piste quando cambia il gioco
 gameEl.addEventListener('change', async ()=>{
-  const res = await fetch('/api/tracks.php?game='+encodeURIComponent(gameEl.value));
+  const res = await fetch('api/tracks.php?game='+encodeURIComponent(gameEl.value));
   const list = await res.json();
   trackEl.innerHTML = list.map(t=>`<option value="${t.id}">${t.name}</option>`).join('');
 });


### PR DESCRIPTION
## Summary
- bootstrap authentication in the hotlap index page so we know when a user is MetaVerse Pro
- render a download call-to-action next to each hotlap that is enabled only for MetaVerse Pro subscribers
- add a secure download endpoint that blocks non-Pro users and serves a placeholder setup file

## Testing
- php -l simhub/public/index.php
- php -l simhub/public/download.php

------
https://chatgpt.com/codex/tasks/task_e_68dcf543e7348325858c5c49859364b5